### PR TITLE
Update dex to handle market routes

### DIFF
--- a/src/components/Dex.vue
+++ b/src/components/Dex.vue
@@ -106,7 +106,12 @@ export default {
       this.$store.dispatch('fetchMarkets', {
         done: () => {
           if (!this.$store.state.currentMarket) {
-            this.$store.commit('setCurrentMarket', this.$store.state.markets[0]);
+            const marketData = this.$services.dex.getMarketDataFromName(this.$route.params.market);
+            if (marketData === false) {
+              this.$router.push(this.$services.dex.getDefaultRoute());
+              return;
+            }
+            this.$store.commit('setCurrentMarket', marketData);
           }
         },
       });
@@ -193,6 +198,12 @@ export default {
     });
 
     services.neo.promptGASFractureIfNecessary();
+  },
+
+  beforeRouteUpdate(to, from, next) {
+    const marketData = this.$services.dex.getMarketDataFromName(to.params.market);
+    this.$store.commit('setCurrentMarket', marketData);
+    next();
   },
 };
 </script>

--- a/src/components/Dex.vue
+++ b/src/components/Dex.vue
@@ -107,8 +107,8 @@ export default {
         done: () => {
           if (!this.$store.state.currentMarket) {
             const marketData = this.$services.dex.getMarketDataFromName(this.$route.params.market);
-            if (marketData === false) {
-              this.$router.push(this.$services.dex.getDefaultRoute());
+            if (!marketData) {
+              this.$router.push(this.$constants.defaultSettings.LANDING_ROUTE);
               return;
             }
             this.$store.commit('setCurrentMarket', marketData);
@@ -202,6 +202,10 @@ export default {
 
   beforeRouteUpdate(to, from, next) {
     const marketData = this.$services.dex.getMarketDataFromName(to.params.market);
+    if (!marketData) {
+      this.$router.push(this.$constants.defaultSettings.LANDING_ROUTE);
+      return;
+    }
     this.$store.commit('setCurrentMarket', marketData);
     next();
   },

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -17,7 +17,7 @@
           </span>
           <span class="label">{{ $t('dashboard') }}</span>
         </router-link>
-        <router-link to="/app/trade/NEO-APH">
+        <router-link :to="$constants.defaultSettings.LANDING_ROUTE">
           <span class="icon">
             <aph-icon name="dex"></aph-icon>
           </span>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -17,7 +17,7 @@
           </span>
           <span class="label">{{ $t('dashboard') }}</span>
         </router-link>
-        <router-link to="/app/dex">
+        <router-link to="/app/trade/NEO-APH">
           <span class="icon">
             <aph-icon name="dex"></aph-icon>
           </span>

--- a/src/components/dex/MarketMegaSelector.vue
+++ b/src/components/dex/MarketMegaSelector.vue
@@ -17,7 +17,7 @@
             <div>{{ $t('vol') }} <span class="small">{{ baseCurrency }}</span></div>
         </div>
         <div class="body">
-          <div @click="market.marketName !== $store.state.currentMarket.marketName ? selectMarket(market) : null" 
+          <div @click="market.marketName !== $store.state.currentMarket.marketName ? selectMarket(market) : null"
             :class="['row', {selected: $store.state.currentMarket && market.marketName === $store.state.currentMarket.marketName }]"
                v-for="market in filteredMarkets" :key="market.marketName">
             <div class="cell flex-horizontal">
@@ -107,7 +107,8 @@ export default {
     },
 
     selectMarket(market) {
-      this.$store.commit('setCurrentMarket', market);
+      const route = this.$constants.defaultSettings.DEX_BASE_ROUTE + market.marketName;
+      this.$router.push(route);
       this.close();
     },
   },
@@ -147,7 +148,7 @@ export default {
       white-space: nowrap;
       font-size: toRem(20px);
     }
-    
+
     .disabled {
       font-size: toRem(12px);
     }
@@ -242,7 +243,7 @@ export default {
           .cell {
             display: flex;
             font-size: toRem(16px);
-            
+
             &.disabled {
               font-size: toRem(11px);
               text-align: right;

--- a/src/constants.js
+++ b/src/constants.js
@@ -56,6 +56,8 @@ const database = {
 const defaultSettings = {
   CURRENCY: 'USD',
   STYLE: 'Day',
+  DEX_BASE_ROUTE: '/app/trade/',
+  DEX_MARKET_PAIR: 'NEO-APH',
 };
 
 const formats = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -57,7 +57,7 @@ const defaultSettings = {
   CURRENCY: 'USD',
   STYLE: 'Day',
   DEX_BASE_ROUTE: '/app/trade/',
-  DEX_MARKET_PAIR: 'NEO-APH',
+  LANDING_ROUTE: '/app/trade/NEO-APH',
 };
 
 const formats = {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -121,7 +121,7 @@ export default new Router({
           component: require('@/components/Commit').default,
         },
         {
-          path: 'dex',
+          path: 'trade/:market',
           component: require('@/components/Dex').default,
           meta: {
             isMenuToggleable: true,

--- a/src/services/dex.js
+++ b/src/services/dex.js
@@ -2888,4 +2888,19 @@ export default {
     // console.log(`${JSON.stringify(res)}`);
     return res.data.kycStatus;
   },
+
+  getMarketDataFromName(marketName) {
+    let marketData = false;
+    store.state.markets.forEach((market) => {
+      if (market.marketName === marketName) {
+        marketData = market;
+      }
+    });
+    return marketData;
+  },
+
+  getDefaultRoute() {
+    const defaultSettings = this.$constants.defaultSettings;
+    return defaultSettings.DEX_BASE_ROUTE + defaultSettings.DEX_MARKET_PAIR;
+  },
 };

--- a/src/services/dex.js
+++ b/src/services/dex.js
@@ -2890,17 +2890,7 @@ export default {
   },
 
   getMarketDataFromName(marketName) {
-    let marketData = false;
-    store.state.markets.forEach((market) => {
-      if (market.marketName === marketName) {
-        marketData = market;
-      }
-    });
-    return marketData;
-  },
-
-  getDefaultRoute() {
-    const defaultSettings = this.$constants.defaultSettings;
-    return defaultSettings.DEX_BASE_ROUTE + defaultSettings.DEX_MARKET_PAIR;
+    const marketData = _.find(store.state.markets, { marketName });
+    return marketData || false;
   },
 };


### PR DESCRIPTION
## Features
* Allows a direct url to be shared for each market pair (e.g. https://dex.aphelion.org/#/app/trade/NEO-NEX)
* Allows forwards/backwards navigating in the browser between market pairs

## Changes
* Dex component loads currentMarket from the /trade/:market route param
* Handles invalid market (e.g. "/app/trade/invalid") - redirects to default market: NEO-APH
* Updated megamenu to change the route only
* Added beforeRouteUpdate method to setCurrentMarket when route/market changes
* Updated sidebar to point "Trade DEX" to /app/trade/NEO-APH

## Notes
* Please pull and test if possible first
* Also, think of anything I may not be aware of?
* Uses fetchMarkets data for validation so new markets will automatically work in the future
