### PR TITLE
Persist dex and commit info modals for browser refreshes

### DIFF
--- a/src/components/Commit.vue
+++ b/src/components/Commit.vue
@@ -105,7 +105,7 @@
         </button>
       </div>
     </div>
-    <commit-info v-if="shouldShowInfoModal"></commit-info>
+    <commit-info v-if="!$store.state.acceptCommitInfo"></commit-info>
     <commit-modal v-if="$store.state.commitModalModel"
       :onConfirmed="commitConfirmed" :onCancel="hideCommitModal"></commit-modal>
     <claim-modal v-if="$store.state.claimModalModel"
@@ -141,6 +141,8 @@ export default {
     loadCommitStateIntervalId = setInterval(() => {
       this.$store.dispatch('fetchCommitState');
     }, this.$constants.intervals.HOLDINGS_POLLING);
+
+    this.setInfoAcceptedFromStorage();
   },
 
   data() {
@@ -158,9 +160,6 @@ export default {
     ...mapGetters([
       'currentNetwork',
     ]),
-    shouldShowInfoModal() {
-      return (!this.$store.state.acceptCommitInfo && !storage.get('commitInfoAccepted'));
-    },
     shouldDisableCommitButton() {
       return this.$store.state.commitState.quantityCommitted > 0 || this.$store.state.commitChangeInProgress;
     },
@@ -203,7 +202,6 @@ export default {
 
   methods: {
     showInfo() {
-      storage.delete('commitInfoAccepted');
       this.$store.commit('setAcceptCommitInfo', false);
     },
     showCommitModal() {
@@ -245,6 +243,12 @@ export default {
 
     compound() {
       this.$services.dex.compoundAPH();
+    },
+
+    setInfoAcceptedFromStorage() {
+      if (storage.get('commitInfoAccepted') === true) {
+        this.$store.commit('setAcceptCommitInfo', true);
+      }
     },
   },
 };

--- a/src/components/Commit.vue
+++ b/src/components/Commit.vue
@@ -105,7 +105,7 @@
         </button>
       </div>
     </div>
-    <commit-info v-if="!$store.state.acceptCommitInfo"></commit-info>
+    <commit-info v-if="shouldShowInfoModal"></commit-info>
     <commit-modal v-if="$store.state.commitModalModel"
       :onConfirmed="commitConfirmed" :onCancel="hideCommitModal"></commit-modal>
     <claim-modal v-if="$store.state.claimModalModel"
@@ -119,6 +119,7 @@ import { mapGetters } from 'vuex';
 import CommitInfo from './modals/CommitInfo';
 import CommitModal from './modals/CommitModal';
 import ClaimModal from './modals/ClaimModal';
+import storage from '../services/storage';
 
 let loadCommitStateIntervalId;
 export default {
@@ -157,6 +158,9 @@ export default {
     ...mapGetters([
       'currentNetwork',
     ]),
+    shouldShowInfoModal() {
+      return (!this.$store.state.acceptCommitInfo && !storage.get('commitInfoAccepted'));
+    },
     shouldDisableCommitButton() {
       return this.$store.state.commitState.quantityCommitted > 0 || this.$store.state.commitChangeInProgress;
     },

--- a/src/components/Commit.vue
+++ b/src/components/Commit.vue
@@ -203,6 +203,7 @@ export default {
 
   methods: {
     showInfo() {
+      storage.delete('commitInfoAccepted');
       this.$store.commit('setAcceptCommitInfo', false);
     },
     showCommitModal() {

--- a/src/components/Dex.vue
+++ b/src/components/Dex.vue
@@ -40,6 +40,7 @@ import { mapGetters } from 'vuex';
 import DexDemoConfirmation from './modals/DexDemoConfirmation';
 import DexOutOfDate from './modals/DexOutOfDate';
 import assets from '../services/assets';
+import storage from '../services/storage';
 
 export default {
   beforeDestroy() {
@@ -66,7 +67,7 @@ export default {
     },
 
     shouldShowDemoConfirmation() {
-      return (!this.acceptDexDemoVersion && !this.isOutOfDate) || this.showLearnMore;
+      return (!this.acceptDexDemoVersion && !storage.get('dexInfoAccepted') && !this.isOutOfDate) || this.showLearnMore;
     },
 
     shouldShowOutOfDate() {

--- a/src/components/Dex.vue
+++ b/src/components/Dex.vue
@@ -67,7 +67,7 @@ export default {
     },
 
     shouldShowDemoConfirmation() {
-      return (!this.acceptDexDemoVersion && !storage.get('dexInfoAccepted') && !this.isOutOfDate) || this.showLearnMore;
+      return (!this.acceptDexDemoVersion && !this.isOutOfDate) || this.showLearnMore;
     },
 
     shouldShowOutOfDate() {
@@ -141,6 +141,12 @@ export default {
 
       this.connected = true;
     },
+
+    setInfoAcceptedFromStorage() {
+      if (storage.get('dexInfoAccepted') === true) {
+        this.$store.commit('setAcceptDexDemoVersion', true);
+      }
+    },
   },
 
   mounted() {
@@ -195,6 +201,8 @@ export default {
     });
 
     services.neo.promptGASFractureIfNecessary();
+
+    this.setInfoAcceptedFromStorage();
   },
 };
 </script>

--- a/src/components/modals/CommitInfo.vue
+++ b/src/components/modals/CommitInfo.vue
@@ -20,6 +20,7 @@
 
 <script>
 import ModalWrapper from './ModalWrapper';
+import storage from '../../services/storage';
 export default {
   components: {
     ModalWrapper,
@@ -28,6 +29,8 @@ export default {
   methods: {
     accept() {
       this.$store.commit('setAcceptCommitInfo', true);
+      // Persist this on desktop web due to many refreshes and emptied state
+      storage.set('commitInfoAccepted', true);
     },
   },
 };
@@ -40,7 +43,7 @@ export default {
     width: toRem(700px);
     overflow: visible;
   }
-  
+
   .body {
     display: block;
     padding: $space-xl;
@@ -56,15 +59,15 @@ export default {
       line-height: $copy-line-height;
       margin: 0;
     }
-    
-      
-        
+
+
+
     .icons {
       position: relative;
       margin: toRem(-80px) auto toRem(80px) auto;
       width: toRem(40px);
-      height: toRem(40px);     
-          
+      height: toRem(40px);
+
       .aph-icon {
         position: absolute;
         width: toRem(40px);
@@ -75,14 +78,14 @@ export default {
             position: relative;
             margin-top: 10%;
           }
-            
+
           &.commit {
             margin: toRem(5px) 0 0 0;
             .fill {
               fill: white;
             }
           }
-            
+
           &.hex {
             margin: toRem(-25px);
             .fill {
@@ -91,7 +94,7 @@ export default {
           }
         }
       }
-    }  
+    }
   }
 
   .footer {

--- a/src/components/modals/CommitInfo.vue
+++ b/src/components/modals/CommitInfo.vue
@@ -20,7 +20,6 @@
 
 <script>
 import ModalWrapper from './ModalWrapper';
-import storage from '../../services/storage';
 export default {
   components: {
     ModalWrapper,
@@ -29,8 +28,6 @@ export default {
   methods: {
     accept() {
       this.$store.commit('setAcceptCommitInfo', true);
-      // Persist this on desktop web due to many refreshes and emptied state
-      storage.set('commitInfoAccepted', true);
     },
   },
 };

--- a/src/components/modals/DexDemoConfirmation.vue
+++ b/src/components/modals/DexDemoConfirmation.vue
@@ -19,6 +19,7 @@
 
 <script>
 import ModalWrapper from './ModalWrapper';
+import storage from '../../services/storage';
 export default {
   components: {
     ModalWrapper,
@@ -28,6 +29,8 @@ export default {
     accept() {
       this.$store.commit('setAcceptDexDemoVersion', true);
       this.$store.commit('setShowLearnMore', false);
+      // Persist this on desktop web due to many refreshes and emptied state
+      storage.set('dexInfoAccepted', true);
     },
   },
 

--- a/src/components/modals/DexDemoConfirmation.vue
+++ b/src/components/modals/DexDemoConfirmation.vue
@@ -19,7 +19,6 @@
 
 <script>
 import ModalWrapper from './ModalWrapper';
-import storage from '../../services/storage';
 export default {
   components: {
     ModalWrapper,
@@ -29,8 +28,6 @@ export default {
     accept() {
       this.$store.commit('setAcceptDexDemoVersion', true);
       this.$store.commit('setShowLearnMore', false);
-      // Persist this on desktop web due to many refreshes and emptied state
-      storage.set('dexInfoAccepted', true);
     },
   },
 

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 
 import { requests } from '../constants';
 import { alerts, neo, dex } from '../services';
+import storage from '../services/storage';
 
 export {
   addToOrderHistory,
@@ -132,6 +133,8 @@ function handleLogout(state) {
   state.menuToggleable = false;
   state.orderHistory = [];
   neo.fetchNEP5Tokens();
+  storage.delete('dexInfoAccepted');
+  storage.delete('commitInfoAccepted');
 }
 
 function handleNetworkChange(state) {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -182,10 +182,24 @@ function resetRequests(state) {
 }
 
 function setAcceptCommitInfo(state, value) {
+  if (value === false && storage.get('commitInfoAccepted')) {
+    storage.delete('commitInfoAccepted');
+  }
+
+  if (value === true) {
+    storage.set('commitInfoAccepted', true);
+  }
   state.acceptCommitInfo = value;
 }
 
 function setAcceptDexDemoVersion(state, value) {
+  if (value === false && storage.get('dexInfoAccepted')) {
+    storage.delete('dexInfoAccepted');
+  }
+
+  if (value === true) {
+    storage.set('dexInfoAccepted', true);
+  }
   Vue.set(state.acceptDexDemoVersion, state.currentNetwork.net, value);
 }
 

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -182,22 +182,18 @@ function resetRequests(state) {
 }
 
 function setAcceptCommitInfo(state, value) {
-  if (value === false && storage.get('commitInfoAccepted')) {
+  if (!value && state.acceptCommitInfo) {
     storage.delete('commitInfoAccepted');
-  }
-
-  if (value === true) {
+  } else if (value && !state.acceptCommitInfo) {
     storage.set('commitInfoAccepted', true);
   }
   state.acceptCommitInfo = value;
 }
 
 function setAcceptDexDemoVersion(state, value) {
-  if (value === false && storage.get('dexInfoAccepted')) {
+  if (!value && state.acceptDexDemoVersion[state.currentNetwork.net]) {
     storage.delete('dexInfoAccepted');
-  }
-
-  if (value === true) {
+  } else if (value && !state.acceptDexDemoVersion[state.currentNetwork.net]) {
     storage.set('dexInfoAccepted', true);
   }
   Vue.set(state.acceptDexDemoVersion, state.currentNetwork.net, value);


### PR DESCRIPTION
## Features
* Allows refreshing of the app/browser without requiring to accept dex and commit info modals every time (much better experience for [dex.aphelion.org](https://dex.aphelion.org) users)

## Notes
* Uses localStorage for persistent data (similar to how currentWallet is persisted on page reloads)
* Clears these keys on logout; so logging into a wallet will pop them up again
* Both 'Learn More' buttons on dex and commit pages still work
* Will still show up for first time users and do what they're there for (e.g. explaining to buy APH)