### PR TITLE
Set landing page to dex

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -27,7 +27,7 @@ export default {
 
   mounted() {
     if (this.$services.wallets.getCurrentWallet()) {
-      this.$router.push('/app/dashboard');
+      this.$router.push(this.$constants.defaultSettings.LANDING_ROUTE);
     }
   },
 };

--- a/src/components/login/EncryptedKey.vue
+++ b/src/components/login/EncryptedKey.vue
@@ -35,7 +35,7 @@ export default {
         encryptedKey: this.encryptedKey,
         passphrase: this.passphrase,
         done: () => {
-          this.$router.push('/app/dashboard');
+          this.$router.push(this.$constants.defaultSettings.LANDING_ROUTE);
         },
       });
     },

--- a/src/components/login/Ledger.vue
+++ b/src/components/login/Ledger.vue
@@ -78,7 +78,7 @@ export default {
 
       await this.$store.dispatch('openLedger', {
         done: () => {
-          this.$router.push('/app/dashboard');
+          this.$router.push(this.$constants.defaultSettings.LANDING_ROUTE);
         },
         failed: () => {
           this.connected = false;

--- a/src/components/login/PrivateKey.vue
+++ b/src/components/login/PrivateKey.vue
@@ -32,7 +32,7 @@ export default {
       this.$store.dispatch('openPrivateKey', {
         wif: this.wif,
         done: () => {
-          this.$router.push('/app/dashboard');
+          this.$router.push(this.$constants.defaultSettings.LANDING_ROUTE);
         },
       });
     },

--- a/src/components/login/SavedWallet.vue
+++ b/src/components/login/SavedWallet.vue
@@ -59,7 +59,7 @@ export default {
         name: this.wallet,
         passphrase: this.passphrase,
         done: () => {
-          this.$router.push('/app/dashboard');
+          this.$router.push(this.$constants.defaultSettings.LANDING_ROUTE);
         },
       });
     },

--- a/src/constants.js
+++ b/src/constants.js
@@ -56,6 +56,7 @@ const database = {
 const defaultSettings = {
   CURRENCY: 'USD',
   STYLE: 'Day',
+  LANDING_ROUTE: '/app/dex',
 };
 
 const formats = {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -189,7 +189,7 @@ export default new Router({
     },
     {
       path: '*',
-      redirect: '/app/dashboard',
+      redirect: '/app/dex',
     },
   ],
 });


### PR DESCRIPTION
## Features
* Sets the landing page for [dex.aphelion.org](https://dex.aphelion.org) to the dex page. It is DEX.aphelion.org after all :)

## Changes
* When logging in via any of the methods, it now sends the user to /app/dex instead of /app/dashboard
* When loading the app with no route (ie. just https://dex.aphelion.org) and the user is logged in, they will be sent to /app/dex
* Added landing page as a defaultSettings constant so only need to change in one place in the future.

## Notes
* defaultSettings constant has been updated in another PR so may need to double check if/when merging into master
* Currently the landing page constant is set as /app/dex however if the /trade/:market PR goes ahead, this will just need changing to /app/trade/NEO-APH
