### PR TITLE
Redirect user to desired page after login (using login ref)

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -14,6 +14,10 @@
   </section>
 </template>
 <script>
+import { defaultSettings } from '../constants';
+import { store } from '../store';
+import router from '../router';
+
 export default {
   beforeDestroy() {
     this.$store.commit('resetRequests');
@@ -29,6 +33,15 @@ export default {
     if (this.$services.wallets.getCurrentWallet()) {
       this.$router.push(this.$constants.defaultSettings.LANDING_ROUTE);
     }
+  },
+
+  beforeRouteEnter(to, from, next) {
+    if (Object.prototype.hasOwnProperty.call(to.query, 'ref')) {
+      store.commit('setLoginRef', to.query.ref);
+      router.replace(defaultSettings.LOGIN_ROUTE);
+      return;
+    }
+    next();
   },
 };
 </script>

--- a/src/components/login/EncryptedKey.vue
+++ b/src/components/login/EncryptedKey.vue
@@ -34,9 +34,7 @@ export default {
       this.$store.dispatch('openEncryptedKey', {
         encryptedKey: this.encryptedKey,
         passphrase: this.passphrase,
-        done: () => {
-          this.$router.push(this.$constants.defaultSettings.LANDING_ROUTE);
-        },
+        done: this.$services.login.success,
       });
     },
   },

--- a/src/components/login/Ledger.vue
+++ b/src/components/login/Ledger.vue
@@ -77,9 +77,7 @@ export default {
       }
 
       await this.$store.dispatch('openLedger', {
-        done: () => {
-          this.$router.push(this.$constants.defaultSettings.LANDING_ROUTE);
-        },
+        done: this.$services.login.success,
         failed: () => {
           this.connected = false;
         },

--- a/src/components/login/PrivateKey.vue
+++ b/src/components/login/PrivateKey.vue
@@ -1,6 +1,6 @@
 <template>
   <section id="login--saved-wallet">
-    <login-form-wrapper identifier="openPrivateKey" :on-submit="login">
+    <login-form-wrapper identifier="openPrivateKey">
       <aph-input :hasError="$isFailed('openPrivateKey')" v-model="wif" :placeholder="$t('enterYourPrivateKeyWIF')" type="password"></aph-input>
       <button class="login" @click="login" :disabled="shouldDisableLoginButton">{{$t('login')}}</button>
     </login-form-wrapper>
@@ -31,9 +31,7 @@ export default {
     login() {
       this.$store.dispatch('openPrivateKey', {
         wif: this.wif,
-        done: () => {
-          this.$router.push(this.$constants.defaultSettings.LANDING_ROUTE);
-        },
+        done: this.$services.login.success,
       });
     },
   },

--- a/src/components/login/PrivateKey.vue
+++ b/src/components/login/PrivateKey.vue
@@ -1,8 +1,8 @@
 <template>
   <section id="login--saved-wallet">
-    <login-form-wrapper identifier="openPrivateKey">
+    <login-form-wrapper identifier="openPrivateKey" :on-submit="login">
       <aph-input :hasError="$isFailed('openPrivateKey')" v-model="wif" :placeholder="$t('enterYourPrivateKeyWIF')" type="password"></aph-input>
-      <button class="login" @click="login" :disabled="shouldDisableLoginButton">{{$t('login')}}</button>
+      <button class="login" :disabled="shouldDisableLoginButton">{{$t('login')}}</button>
     </login-form-wrapper>
   </section>
 </template>

--- a/src/components/login/SavedWallet.vue
+++ b/src/components/login/SavedWallet.vue
@@ -58,9 +58,7 @@ export default {
       this.$store.dispatch('openSavedWallet', {
         name: this.wallet,
         passphrase: this.passphrase,
-        done: () => {
-          this.$router.push(this.$constants.defaultSettings.LANDING_ROUTE);
-        },
+        done: this.$services.login.success,
       });
     },
     create() {

--- a/src/constants.js
+++ b/src/constants.js
@@ -57,6 +57,7 @@ const defaultSettings = {
   CURRENCY: 'USD',
   STYLE: 'Day',
   LANDING_ROUTE: '/app/dex',
+  LOGIN_ROUTE: '/login',
 };
 
 const formats = {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -76,7 +76,7 @@ export default new Router({
           return next();
         }
 
-        return next('/login');
+        return next(`/login?ref=${to.path}`);
       },
       children: [
         {

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -3,6 +3,7 @@ import assets from './assets';
 import contacts from './contacts';
 import formatting from './formatting';
 import ledger from './ledger';
+import login from './login';
 import neo from './neo';
 import network from './network';
 import settings from './settings';
@@ -18,6 +19,7 @@ export {
   dex,
   formatting,
   ledger,
+  login,
   neo,
   network,
   settings,

--- a/src/services/login.js
+++ b/src/services/login.js
@@ -1,0 +1,17 @@
+import { defaultSettings } from '../constants';
+import router from '../router';
+import { store } from '../store';
+
+export default {
+
+  success() {
+    let redirect = defaultSettings.LANDING_ROUTE;
+
+    if (store.state.loginRef) {
+      redirect = store.state.loginRef;
+      store.commit('setLoginRef', false);
+    }
+
+    router.push(redirect);
+  },
+};

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -39,6 +39,7 @@ const state = {
   lastReceivedBlock: null,
   lastSuccessfulRequest: null,
   latestVersion: null,
+  loginRef: false,
   markets: [],
   menuToggleable: false,
   menuCollapsed: true,

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -44,6 +44,7 @@ export {
   setLastReceivedBlock,
   setLastSuccessfulRequest,
   setLatestVersion,
+  setLoginRef,
   setMarkets,
   setMenuCollapsed,
   setMenuToggleable,
@@ -181,6 +182,10 @@ function putBlockDetails(state, blockDetails) {
 
 function resetRequests(state) {
   state.requests = {};
+}
+
+function setLoginRef(state, value) {
+  state.loginRef = value;
 }
 
 function setAcceptCommitInfo(state, value) {


### PR DESCRIPTION
## Features
* Enables a user to still be routed to their desired page if login is required first. For example, if a user wants to go to /app/trade/NEO-APH but aren't logged into their wallet, they will be redirected to the login page. However, once login is successful, they will be taken to the original page they wanted to go to.

## Changes
* On the router object, beforeEnter sends the user to /login?ref={route} if they are trying to access an authenticated only route while unauthenticated.
* Login.vue catches that on beforeRouteEnter, sets state.loginRef and replaces route with just /login (for aethstetic purposes).
* Logging in via any method now calls the services.login.success method. This checks for state.loginRef to overwrite the redirect.